### PR TITLE
WIP: Add caching for average_spectra

### DIFF
--- a/gofish/gofish.py
+++ b/gofish/gofish.py
@@ -50,6 +50,8 @@ class imagecube(object):
         if self.data.ndim != 3 and self.verbose:
             print("WARNING: Provided cube is only 2D. Shifting not available.")
 
+        self._cached_average_spectra={}
+
     # -- Fishing Functions -- #
 
     def average_spectrum(self, r_min=None, r_max=None, dr=None,
@@ -154,6 +156,20 @@ class imagecube(object):
             bin, ``scatter``. The latter two are in units of either [Jy/beam]
             or [K] depending on the ``unit``.
         """
+        # Check whether this tuple of inputs was already calculated
+        args = (r_min, r_max, dr,
+                PA_min, PA_max, exclude_PA,
+                abs_PA, x0, y0, inc, PA, z0,
+                psi, z1, phi, z_func, mstar,
+                dist, resample, beam_spacing,
+                mask_frame, unit.lower(), mask,
+                assume_correlated, skip_empty_annuli,
+                shadowed)
+        print(args)
+        if args in self._cached_average_spectra.keys():
+            print("Using cached!")
+            return self._cached_average_spectra[args]
+
         # Check is cube is 2D.
         self._test_2D()
 
@@ -251,6 +267,7 @@ class imagecube(object):
         if unit[0] == 'm':
             spectrum *= 1e3
             scatter *= 1e3
+        self._cached_average_spectra[args] = x, spectrum, scatter
         return x, spectrum, scatter
 
     def integrated_spectrum(self, r_min=None, r_max=None, dr=None, x0=0.0,
@@ -503,7 +520,7 @@ class imagecube(object):
                        z0=0.0, psi=1.0, z1=0.0, phi=1.0, z_func=None,
                        mstar=1.0, dist=100., resample=1, beam_spacing=False,
                        r_min=None, r_max=None, PA_min=None, PA_max=None,
-                       exclude_PA=False, abs_PA=False, mask_frame='disk',
+                       exclude_PA=None, abs_PA=False, mask_frame='disk',
                        velo_range=None, assume_correlated=True, shadowed=True):
         """
         Generate a radial profile from shifted and stacked spectra. There are


### PR DESCRIPTION
Hi Rich,
I have added to the very beginning of average_spectrum:```# Check whether this tuple of inputs was already calculated
```python
args = (r_min, r_max, dr,
 PA_min, PA_max, exclude_PA,
 abs_PA, x0, y0, inc, PA, z0,
 psi, z1, phi, z_func, mstar,
 dist, resample, beam_spacing,
 mask_frame, unit.lower(), mask,
 assume_correlated, skip_empty_annuli,
 shadowed)
if args in self._cached_average_spectra.keys():
 return self._cached_average_spectra[args]
```
This does not really work, unfortunately. If I run radial_spectra, integrated_spectrum, radial_profile one by one with the same kwargs and output args, here is what I get:
radial_spectra
```
(0.0, 0.30958002500805, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.30958002500805, 0.6191600500161, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.6191600500161, 0.9287400750241499, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.9287400750241499, 1.2383201000322, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.2383201000322, 1.54790012504025, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.54790012504025, 1.8574801500482998, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.8574801500482998, 2.16706017505635, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.16706017505635, 2.4766402000644, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.4766402000644, 2.7862202250724497, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.7862202250724497, 3.0958002500805, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.0958002500805, 3.40538027508855, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.40538027508855, 3.7149603000965996, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.7149603000965996, 4.02454032510465, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.02454032510465, 4.3341203501127, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.3341203501127, 4.6437003751207495, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.6437003751207495, 4.9532804001288, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.9532804001288, 5.26286042513685, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.26286042513685, 5.572440450144899, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.572440450144899, 5.88202047515295, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.88202047515295, 6.191600500161, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.191600500161, 6.501180525169049, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.501180525169049, 6.8107605501771, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.8107605501771, 7.12034057518515, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(7.12034057518515, 7.429920600193199, None, None, None, None, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
integrated_spectrum
(None, None, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)

radial_profile
(0.0, 0.30958002500805, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.30958002500805, 0.6191600500161, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.6191600500161, 0.9287400750241499, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(0.9287400750241499, 1.2383201000322, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.2383201000322, 1.54790012504025, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.54790012504025, 1.8574801500482998, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(1.8574801500482998, 2.16706017505635, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.16706017505635, 2.4766402000644, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.4766402000644, 2.7862202250724497, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(2.7862202250724497, 3.0958002500805, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.0958002500805, 3.40538027508855, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.40538027508855, 3.7149603000965996, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(3.7149603000965996, 4.02454032510465, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.02454032510465, 4.3341203501127, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.3341203501127, 4.6437003751207495, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.6437003751207495, 4.9532804001288, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(4.9532804001288, 5.26286042513685, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.26286042513685, 5.572440450144899, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.572440450144899, 5.88202047515295, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(5.88202047515295, 6.191600500161, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.191600500161, 6.501180525169049, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.501180525169049, 6.8107605501771, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(6.8107605501771, 7.12034057518515, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
(7.12034057518515, 7.429920600193199, None, None, None, False, False, 0, 0, 49.99, 191.22, 0.0, 1.0, 0.0, 1.0, None, 0.89, 158.7, 1, False, 'disk', 'jy/beam', None, False, True, True)
```

So the exclude_PA keyword is by default False within radial_profile, while it is None in radial_spectra. Is it by a reason? If I replace it in the method definition, the cache is used. It is still not used for the integrated_spectrum, as it takes the whole disk at once without radial binning. But in principle, it could do the other way around, by collapsing the known deprojected data?